### PR TITLE
Consistency

### DIFF
--- a/Card.swift
+++ b/Card.swift
@@ -8,29 +8,25 @@
 
 import Foundation
 
-//No inheritance in struct, similar to class
-//Structs are value types, classes are reference types
-//What does that mean?
-//Value type, copied
-//Classes, pointed to
-struct Card
-{
-    
+// No inheritance in struct, similar to class
+// Structs are value types, classes are reference types
+// What does that mean?
+// Value type, copied
+// Classes, pointed to
+struct Card {
+    let identifier: Int
     var isFaceUp = false
     var isMatched = false
-    var isSeen = false;
-    var identifier: Int
+    var isSeen = false
     
     static var identifierFactory = 0
     
-    static func getUniqueIdentifier() -> Int{
-        
+    static func getUniqueIdentifier() -> Int {
         identifierFactory += 1
         return identifierFactory
     }
     
-    init()
-    {
+    init() {
         self.identifier = Card.getUniqueIdentifier()
     }
 }


### PR DESCRIPTION
Keep braces in the same place - it's not important whether they're on the same line as the struct/func/etc, but it _is_ important to be consistent. Pick one style and stick with it. There's software that can check/enforce this for you automatically.

I can't remember (and I'm on a Windows machine currently) if the `let identifier: Int` is valid, though. 